### PR TITLE
Add links to tips in readme

### DIFF
--- a/nlp/README.md
+++ b/nlp/README.md
@@ -2,10 +2,10 @@
 
 Current content:
 
--  _Multilingual Sentence Embeddings_ (21/01/2021):
+-  [_Multilingual Sentence Embeddings_ (21/01/2021)](2021_01_21_multilingual_sentence_embeddings):
 Gives an overview of various current multilingual sentence embedding techniques and tools, and
 how they compare given various sequence lengths.
 
--  _Spacy 3.0_ (01/02/2021) -:
+-  [_Spacy 3.0_ (01/02/2021)](2021_02_01_spacy_3_projects):
 Spacy 3.0 has just been released and in this tip, we'll have a look at some of the new features.  
 We'll be training a German NER model and streamline the end-to-end pipeline using the brand new spaCy projects!


### PR DESCRIPTION
This PR adds links to the tips in the readme, so the reader doesn't have to go and look for the corresponding tip in the list of directories.