### PR TITLE
Adding domain links to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ This repository contains a collection of handy tips and tricks from the ML6 Team
 You can find a number of code-examples, for various ML and Engineering domains, on how we tackle certain problems.
 
 All feedback, pointers and comments are very welcome! We hope you find this repo useful ⭐.
+
+## Domains
+* [Natural Language Processing](nlp)
+* [Structured Data](structured_data)


### PR DESCRIPTION
Added domain links to the main readme to support intuitive navigation. On mobile, for example, code browsing is hidden behind an extra click.

To me this reduces confusion. Let me know what you think.